### PR TITLE
Add "or (len(df) == 0)"

### DIFF
--- a/optimpv/models/DDfits/HysteresisAgent.py
+++ b/optimpv/models/DDfits/HysteresisAgent.py
@@ -326,7 +326,7 @@ class HysteresisAgent(SIMsalabimAgent):
             Dictionary with the target metric value.
         """  
         df = self.run_hysteresis_simulation(parameters)
-        if df is np.nan:
+        if (df is np.nan) or (len(df) == 0):
             dum_dict = {}
             for i in range(len(self.all_agent_metrics)):
                 dum_dict[self.all_agent_metrics[i]] = np.nan


### PR DESCRIPTION
If the tj-file contains headers but no actual values. Then df is not nan, yet it doesn't contain any values so "reformat_hysteresis_data" will result in a ValueError. Therefore, if the length of the dataFrame is 0, the metric in dum_dict should also be set to np.nan